### PR TITLE
Update double quotation in getconfigfromdb.psm1

### DIFF
--- a/helpermodules/getconfigfromdb.psm1
+++ b/helpermodules/getconfigfromdb.psm1
@@ -9,11 +9,11 @@ function get-servicesettingsfromdb ()
     $connection = new-object system.data.SqlClient.SqlConnection($stsWMIObject.ConfigurationDatabaseConnectionString);
     $connection.Open()
   
-    $query = “SELECT * FROM IdentityServerPolicy.ServiceSettings"  
+    $query = "SELECT * FROM IdentityServerPolicy.ServiceSettings"  
     $sqlcmd = $connection.CreateCommand();
     $sqlcmd.CommandText = $query;
     $result = $sqlcmd.ExecuteReader();
-    $table = new-object “System.Data.DataTable”
+    $table = new-object "System.Data.DataTable"
     $table.Load($result)
     [XML]$SSD=  $table.ServiceSettingsData
     return $SSD


### PR DESCRIPTION
Update double quotation in getconfigfromdb.psm1.
It seems the double quotation in getconfigfromdb.psm1 in in different format. It is causing following error on Japanese OS.
------------------------------------------
At C:\Tools\ADFS-Diag-main\helpermodules\getconfigfromdb.psm1:12 char:64
+     $query = 鉄ELECT * FROM IdentityServerPolicy.ServiceSettings"
+                                                                ~
The string is missing the terminator: ".
At C:\Tools\ADFS-Diag-main\helpermodules\getconfigfromdb.psm1:6 char:1
+ {
+ ~
Missing closing '}' in statement block or type definition.
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : TerminatorExpectedAtEndOfString

import-Module : The specified module 'C:\Tools\ADFS-Diag-main\helpermodules\getconfigfromdb.psm1' was not loaded because no valid module file was found in any module directory. At C:\Tools\ADFS-Diag-main\ADFS-tracing.ps1:37 char:1
+ import-Module $PSScriptRoot\helpermodules\getconfigfromdb.psm1
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ResourceUnavailable: (C:\Tools\ADFS-D...nfigfromdb.psm1:String) [Import-Module], FileNotFoundException
    + FullyQualifiedErrorId : Modules_ModuleNotFound,Microsoft.PowerShell.Commands.ImportModuleCommand
------------------------------------------